### PR TITLE
Rebuild 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,156 +1,152 @@
 <!DOCTYPE html>
 <html>
   <head>
-	<meta name="generator" content="Hugo 0.70.0" />
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="width=device-width">
-  <meta name="author" content="keita_kawamoto">
-  <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
-  
+    <meta name="generator" content="Hugo 0.70.0" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="author" content="keita_kawamoto">
+    <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
+    
     <title>Orangebomb</title>
-  
-  
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="keita_kawamoto">
-  <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="Orangebomb">
-  <meta name="twitter:url" content="https://blog.orangebomb.org/">
-  <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
-  
-  <meta property="og:title" content="Orangebomb">
-  <meta property="og:url" content="https://blog.orangebomb.org/">
-  <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
-  
-  
+    
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="keita_kawamoto">
+    <meta name="twitter:creator" content="keita_kawamoto">
+    <meta name="twitter:title" content="Orangebomb">
+    <meta name="twitter:url" content="https://blog.orangebomb.org/">
+    <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
+    
+    <meta property="og:title" content="Orangebomb">
+    <meta property="og:url" content="https://blog.orangebomb.org/">
+    <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
+    
     <meta property="og:image" content="https://blog.orangebomb.org/images/ogp.png">
     <meta name="twitter:image" content="https://blog.orangebomb.org/images/ogp.png">
-  
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/header.css">
-  <link rel="stylesheet" href="/css/contents.css">
-  <link rel="stylesheet" href="/css/footer.css">
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
-  <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
-  <link rel="shortcut icon" href="/images/favicon.ico">
-  <link rel="canonical" href="https://blog.orangebomb.org/">
-</head>
+    
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/css/base.css">
+    <link rel="stylesheet" href="/css/header.css">
+    <link rel="stylesheet" href="/css/contents.css">
+    <link rel="stylesheet" href="/css/footer.css">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
+    <link rel="shortcut icon" href="/images/favicon.ico">
+    <link rel="canonical" href="https://blog.orangebomb.org/">
+  </head>
 
   <body>
     <div class="header">
-  <div class="header-inner">
-    <header>
-      <h1 class="logo"><a href="https://blog.orangebomb.org"><img src="https://blog.orangebomb.org/images/logo.svg" alt="Orangebomb"></a></h1>
-      <nav>
-        <ul class="menu">
-          <li><a href="/post">ARCHIVES</a></li>
-          <li><a href="/tags">TAGS</a></li>
-          <li><a href="#profile">PROFILE</a></li>
-        </ul>
-      </nav>
-    </header>
-  </div>
-</div>
+      <div class="header-inner">
+        <header>
+          <h1 class="logo"><a href="https://blog.orangebomb.org"><img src="https://blog.orangebomb.org/images/logo.svg" alt="Orangebomb"></a></h1>
+          <nav>
+            <ul class="menu">
+              <li><a href="/post">ARCHIVES</a></li>
+              <li><a href="/tags">TAGS</a></li>
+              <li><a href="#profile">PROFILE</a></li>
+            </ul>
+          </nav>
+        </header>
+      </div>
+    </div>
 
-    
     <div class="container">
       <div class="posts">
         
         <article>
-  <div class="post">
-    <header>
-      <h1><a href="https://blog.orangebomb.org/post/">Posts</a></h1>
-      <div class="post-date">
-        <div class="day">
-          <time>2020-05-07</time>
-        </div>
-        <div class="tags">
-          <i class="fa fa-tags tag-icon" aria-hidden="true"></i>
-          <span class="sr-only">Tags</span>
-          <ul>
-          
-          </ul>
-        </div>
-      </div>
-    </header>
-    <div class="post-inner">
-      
-    </div>
-  </div>
-</article>
+          <div class="post">
+            <header>
+              <h1><a href="https://blog.orangebomb.org/post/">Posts</a></h1>
+              <div class="post-date">
+                <div class="day">
+                  <time>2020-05-07</time>
+                </div>
+                <div class="tags">
+                  <i class="fa fa-tags tag-icon" aria-hidden="true"></i>
+                  <span class="sr-only">Tags</span>
+                  <ul>
+                  
+                  </ul>
+                </div>
+              </div>
+            </header>
+            <div class="post-inner">
+              
+            </div>
+          </div>
+        </article>
 
-        
         <a href="/post" class="archives">Archives</a>
       </div>
     </div>
     <footer class="footer" id="profile">
-  <div class="author">
-    <div class="author-image"></div>
-    <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計 准専門家。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
-  </div>
-  <ul class="social">
-    <li>
-      <a href="https://twitter.com/keita_kawamoto" target="_blank" class="twitter">
-        <i class="fa fa-twitter" aria-hidden="true"></i>
-        <span class="sr-only">Twitter</span>
-      </a>
-    </li>
-    <li>
-      <a href="https://dribbble.com/keita_kawamoto" target="_blank" class="dribbble">
-        <i class="fa fa-dribbble" aria-hidden="true"></i>
-        <span class="sr-only">Dribbble</span>
-      </a>
-    </li>
-    <li>
-      <a href="https://github.com/keitakawamoto" target="_blank" class="github">
-        <i class="fa fa-github" aria-hidden="true"></i>
-        <span class="sr-only">GitHub</span>
-      </a>
-    </li>
-    <li>
-      <a href="https://jp.pinterest.com/keitakawamoto" target="_blank" class="pinterest">
-        <i class="fa fa-pinterest" aria-hidden="true"></i>
-        <span class="sr-only">Pinterest</span>
-      </a>
-    </li>
-    <li>
-      <a href="http://codepen.io/keitakawamoto" target="_blank" class="codepen">
-        <i class="fa fa-codepen" aria-hidden="true"></i>
-        <span class="sr-only">Codepen</span>
-      </a>
-    </li>
-    <li>
-      <a href="https://www.instagram.com/keita_kawamoto" target="_blank" class="instagram">
-        <i class="fa fa-instagram" aria-hidden="true"></i>
-        <span class="sr-only">Instagram</span>
-      </a>
-    </li>
-    <li>
-      <a href="/index.xml" target="_blank" class="rss">
-        <i class="fa fa-rss" aria-hidden="true"></i>
-        <span class="sr-only">RSS</span>
-      </a>
-    </li>
-  </ul>
-  <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
-  </p>
-</footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+      <div class="author">
+        <div class="author-image"></div>
+        <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
+        <p class="author-bio">HCD-Net認定 人間中心設計 准専門家。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+      </div>
+      <ul class="social">
+        <li>
+          <a href="https://twitter.com/keita_kawamoto" target="_blank" class="twitter">
+            <i class="fa fa-twitter" aria-hidden="true"></i>
+            <span class="sr-only">Twitter</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://dribbble.com/keita_kawamoto" target="_blank" class="dribbble">
+            <i class="fa fa-dribbble" aria-hidden="true"></i>
+            <span class="sr-only">Dribbble</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/keitakawamoto" target="_blank" class="github">
+            <i class="fa fa-github" aria-hidden="true"></i>
+            <span class="sr-only">GitHub</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://jp.pinterest.com/keitakawamoto" target="_blank" class="pinterest">
+            <i class="fa fa-pinterest" aria-hidden="true"></i>
+            <span class="sr-only">Pinterest</span>
+          </a>
+        </li>
+        <li>
+          <a href="http://codepen.io/keitakawamoto" target="_blank" class="codepen">
+            <i class="fa fa-codepen" aria-hidden="true"></i>
+            <span class="sr-only">Codepen</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://www.instagram.com/keita_kawamoto" target="_blank" class="instagram">
+            <i class="fa fa-instagram" aria-hidden="true"></i>
+            <span class="sr-only">Instagram</span>
+          </a>
+        </li>
+        <li>
+          <a href="/index.xml" target="_blank" class="rss">
+            <i class="fa fa-rss" aria-hidden="true"></i>
+            <span class="sr-only">RSS</span>
+          </a>
+        </li>
+      </ul>
+      <p class="copyright">
+        <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+      </p>
+    </footer>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
 
-    <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-83267965-1', 'auto');
-  ga('send', 'pageview');
+      ga('create', 'UA-83267965-1', 'auto');
+      ga('send', 'pageview');
 
-</script>
+    </script>
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -55,25 +55,73 @@
       <div class="posts">
         
         <article>
-          <div class="post">
+          <div class="container-inner">
             <header>
-              <h1><a href="https://blog.orangebomb.org/post/">Posts</a></h1>
-              <div class="post-date">
-                <div class="day">
-                  <time>2020-05-07</time>
-                </div>
-                <div class="tags">
-                  <i class="fa fa-tags tag-icon" aria-hidden="true"></i>
-                  <span class="sr-only">Tags</span>
-                  <ul>
-                  
-                  </ul>
-                </div>
-              </div>
+              <h1>Archives</h1>
             </header>
-            <div class="post-inner">
+            <ul class="archives-list">
               
-            </div>
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
+                  <time><span class="list-day">2020-05-07</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
+                  <time><span class="list-day">2018-05-11</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
+                  <time><span class="list-day">2018-05-01</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
+                  <time><span class="list-day">2017-12-10</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
+                  <time><span class="list-day">2017-10-13</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
+                  <time><span class="list-day">2017-10-02</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
+                  <time><span class="list-day">2017-08-25</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
+                  <time><span class="list-day">2017-08-04</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
+                  <time><span class="list-day">2017-07-25</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
+                  <time><span class="list-day">2017-07-19</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
+                  <time><span class="list-day">2017-02-03</span></time>
+                </li>
+              
+                <li>
+                  <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
+                  <time><span class="list-day">2016-11-29</span></time>
+                </li>
+              
+            </ul>
           </div>
         </article>
 


### PR DESCRIPTION
https://github.com/keitakawamoto/orangebomb.org で行っていたHugo運用を廃止する。手動にすることでメリット・デメリットどちらも発生するが、手動を選択する。詳細はRebuild 2 以降に記載する。

これまではworkerがビルド結果をこのリポジトリに反映してたが当然それも廃止、今後は @keitakawamoto が行う。

### 内容

一旦はHugoでビルドされた状態のままにしておく
この変更が反映されるかどうかのテストとして、https://github.com/keitakawamoto/orangebomb.org/pull/186 で壊れたトップページを編集する。取り急ぎアーカイブ一覧を載せる。

壊れたslideshareの埋め込みを修復するのはRebuild 2で行う