### PR TITLE
はてブボタンの削除とツイートボタンの更新１

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -103,13 +103,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>


### PR DESCRIPTION
個人的な判断とメンテ量を削減のための個々のページの極端なシンプル化に伴い、はてブボタンを取り外す。
記事に設置するソーシャルボタンは、今後はツイートボタンのみとする。

また、ツイートボタンのコードも最新のものに差し替える。

---

まずは実験として１記事のみ変更しデプロイする。