### PR TITLE
はてブボタンの削除とツイートボタンの更新２

### DIFF
--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -130,13 +130,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/02/03/output/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -240,13 +240,8 @@ Keynoteの文字が消える問題の解決対応がまだ先になりそうなS
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/07/19/slideshare/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -108,13 +108,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/07/25/brain-science/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -105,13 +105,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -100,13 +100,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/08/25/career-keynote/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -119,13 +119,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/10/02/sangosan/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -254,13 +254,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -133,13 +133,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2017/12/10/anaglyph/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -156,13 +156,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -191,13 +191,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -100,13 +100,8 @@
   </div>
 </article>
 
-      <div class="social-btn">
-  <div>
-    <a href="http://b.hatena.ne.jp/entry/https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>  
-  </div>
-  <div>
-    <a href="https://twitter.com/share" class="twitter-share-button" data-via="keita_kawamoto">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  </div>
+<div class="social-btn">
+  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
     </div>


### PR DESCRIPTION
https://github.com/keitakawamoto/keitakawamoto.github.io/pull/8 で行なったテスト結果問題なかったので全ページで同じ編集を行う。

```
$ pt はてなブックマーク
$ 
```

残留はなし。