### PR TITLE
highlight.jsを廃止

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">
@@ -159,8 +158,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/02/03/output/">
@@ -187,8 +186,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">
@@ -297,8 +296,6 @@ Keynoteの文字が消える問題の解決対応がまだ先になりそうなS
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">
@@ -164,8 +163,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">
@@ -159,8 +158,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">
@@ -157,8 +156,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">
@@ -178,8 +177,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">
@@ -311,8 +310,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">
@@ -185,8 +184,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">
@@ -211,8 +210,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">
@@ -248,8 +247,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">
@@ -154,8 +153,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
     <link rel="stylesheet" href="/css/contents.css">
     <link rel="stylesheet" href="/css/footer.css">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
     <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
     <link rel="shortcut icon" href="/images/favicon.ico">
     <link rel="canonical" href="https://blog.orangebomb.org/">
@@ -181,8 +180,6 @@
         <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
       </p>
     </footer>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-    <script>hljs.initHighlightingOnLoad();</script>
 
         <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/accessibility/">
@@ -131,8 +130,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/cognitive-science-principle-rule/">
@@ -127,8 +126,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/hcd/">
@@ -123,8 +122,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/index.html
+++ b/tags/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/">
@@ -125,8 +124,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/interface-interaction/">
@@ -128,8 +127,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/making/">
@@ -127,8 +126,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/other/">
@@ -133,8 +132,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/research-analysis/">
@@ -127,8 +126,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -30,7 +30,6 @@
   <link rel="stylesheet" href="/css/contents.css">
   <link rel="stylesheet" href="/css/footer.css">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Source+Code+Pro">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github-gist.min.css">
   <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/images/apple-touch-icon-192-precomposed.png">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="canonical" href="https://blog.orangebomb.org/tags/tutorial/">
@@ -128,8 +127,6 @@
     <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
   </p>
 </footer>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
     <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
コードを書くことはまずない+あってもハイライトは不要、それより読み込み量を減らす方が有意義という判断で、[初期のデザイン時に実装したハイライトJS](https://github.com/keitakawamoto/orangebomb.org/pull/9#issuecomment-241352391)を削除する。

残留がないことを確認。
```
$ pt highlight
$
```