### PR TITLE
time要素を最適化する

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2016-11-29</time>
+          <time>2016.11.29</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2016-11-29</time>
+          <time datetime="2016-11-29">2016-11-29</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2016.11.29</time>
+          <time>2016-11-29</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.02.03</time>
+          <time>2017-02-03</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-02-03</time>
+          <time>2017.02.03</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-02-03</time>
+          <time datetime="2017-02-03">2017-02-03</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-07-19</time>
+          <time>2017.07.19</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-07-19</time>
+          <time datetime="2017-07-19">2017-07-19</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.07.19</time>
+          <time>2017-07-19</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-07-25</time>
+          <time datetime="2017-07-25">2017-07-25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.07.25</time>
+          <time>2017-07-25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-07-25</time>
+          <time>2017.07.25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.08.04</time>
+          <time>2017-08-04</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-08-04</time>
+          <time datetime="2017-08-04">2017-08-04</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-08-04</time>
+          <time>2017.08.04</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-08-25</time>
+          <time>2017.08.25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-08-25</time>
+          <time datetime="2017-08-25">2017-08-25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.08.25</time>
+          <time>2017-08-25</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.10.02</time>
+          <time>2017-10-02</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-10-02</time>
+          <time>2017.10.02</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-10-02</time>
+          <time datetime="2017-10-02">2017-10-02</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-10-13</time>
+          <time datetime="2017-10-13">2017-10-13</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.10.13</time>
+          <time>2017-10-13</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-10-13</time>
+          <time>2017.10.13</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-12-10</time>
+          <time>2017.12.10</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017.12.10</time>
+          <time>2017-12-10</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2017-12-10</time>
+          <time datetime="2017-12-10">2017-12-10</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018-05-01</time>
+          <time>2018.05.01</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018-05-01</time>
+          <time datetime="2018-05-01">2018-05-01</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018.05.01</time>
+          <time>2018-05-01</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018.05.11</time>
+          <time>2018-05-11</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018-05-11</time>
+          <time datetime="2018-05-11">2018-05-11</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2018-05-11</time>
+          <time>2018.05.11</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2020-05-07</time>
+          <time datetime="2020-05-07">2020-05-07</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2020.05.07</time>
+          <time>2020-05-07</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -58,7 +58,7 @@
       <h1><a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a></h1>
       <div class="post-date">
         <div class="day">
-          <time>2020-05-07</time>
+          <time>2020.05.07</time>
         </div>
         <div class="tags">
           <i class="fa fa-tags tag-icon" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -62,62 +62,62 @@
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-                  <time><span class="list-day">2020-05-07</span></time>
+                  <time><span class="list-day">2020.05.07</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-                  <time><span class="list-day">2018-05-11</span></time>
+                  <time><span class="list-day">2018.05.11</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-                  <time><span class="list-day">2018-05-01</span></time>
+                  <time><span class="list-day">2018.05.01</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-                  <time><span class="list-day">2017-12-10</span></time>
+                  <time><span class="list-day">2017.12.10</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-                  <time><span class="list-day">2017-10-13</span></time>
+                  <time><span class="list-day">2017.10.13</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-                  <time><span class="list-day">2017-10-02</span></time>
+                  <time><span class="list-day">2017.10.02</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-                  <time><span class="list-day">2017-08-25</span></time>
+                  <time><span class="list-day">2017.08.25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-                  <time><span class="list-day">2017-08-04</span></time>
+                  <time><span class="list-day">2017.08.04</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-                  <time><span class="list-day">2017-07-25</span></time>
+                  <time><span class="list-day">2017.07.25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-                  <time><span class="list-day">2017-07-19</span></time>
+                  <time><span class="list-day">2017.07.19</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-                  <time><span class="list-day">2017-02-03</span></time>
+                  <time><span class="list-day">2017.02.03</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-                  <time><span class="list-day">2016-11-29</span></time>
+                  <time><span class="list-day">2016.11.29</span></time>
                 </li>
               
             </ul>

--- a/index.html
+++ b/index.html
@@ -62,62 +62,62 @@
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-                  <time><span class="list-day">2020-05-07</span></time>
+                  <time datetime="2020-05-07"><span class="list-day">2020-05-07</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-                  <time><span class="list-day">2018-05-11</span></time>
+                  <time datetime="2018-05-11"><span class="list-day">2018-05-11</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-                  <time><span class="list-day">2018-05-01</span></time>
+                  <time datetime="2018-05-01"><span class="list-day">2018-05-01</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-                  <time><span class="list-day">2017-12-10</span></time>
+                  <time datetime="2017-12-10"><span class="list-day">2017-12-10</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-                  <time><span class="list-day">2017-10-13</span></time>
+                  <time datetime="2017-10-13"><span class="list-day">2017-10-13</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-                  <time><span class="list-day">2017-10-02</span></time>
+                  <time datetime="2017-10-02"><span class="list-day">2017-10-02</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-                  <time><span class="list-day">2017-08-25</span></time>
+                  <time datetime="2017-08-25"><span class="list-day">2017-08-25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-                  <time><span class="list-day">2017-08-04</span></time>
+                  <time datetime="2017-08-04"><span class="list-day">2017-08-04</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-                  <time><span class="list-day">2017-07-25</span></time>
+                  <time datetime="2017-07-25"><span class="list-day">2017-07-25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-                  <time><span class="list-day">2017-07-19</span></time>
+                  <time datetime="2017-07-19"><span class="list-day">2017-07-19</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-                  <time><span class="list-day">2017-02-03</span></time>
+                  <time datetime="2017-02-03"><span class="list-day">2017-02-03</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-                  <time><span class="list-day">2016-11-29</span></time>
+                  <time datetime="2016-11-29"><span class="list-day">2016-11-29</span></time>
                 </li>
               
             </ul>

--- a/index.html
+++ b/index.html
@@ -62,62 +62,62 @@
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-                  <time><span class="list-day">2020.05.07</span></time>
+                  <time><span class="list-day">2020-05-07</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-                  <time><span class="list-day">2018.05.11</span></time>
+                  <time><span class="list-day">2018-05-11</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-                  <time><span class="list-day">2018.05.01</span></time>
+                  <time><span class="list-day">2018-05-01</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-                  <time><span class="list-day">2017.12.10</span></time>
+                  <time><span class="list-day">2017-12-10</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-                  <time><span class="list-day">2017.10.13</span></time>
+                  <time><span class="list-day">2017-10-13</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-                  <time><span class="list-day">2017.10.02</span></time>
+                  <time><span class="list-day">2017-10-02</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-                  <time><span class="list-day">2017.08.25</span></time>
+                  <time><span class="list-day">2017-08-25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-                  <time><span class="list-day">2017.08.04</span></time>
+                  <time><span class="list-day">2017-08-04</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-                  <time><span class="list-day">2017.07.25</span></time>
+                  <time><span class="list-day">2017-07-25</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-                  <time><span class="list-day">2017.07.19</span></time>
+                  <time><span class="list-day">2017-07-19</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-                  <time><span class="list-day">2017.02.03</span></time>
+                  <time><span class="list-day">2017-02-03</span></time>
                 </li>
               
                 <li>
                   <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-                  <time><span class="list-day">2016.11.29</span></time>
+                  <time><span class="list-day">2016-11-29</span></time>
                 </li>
               
             </ul>

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -61,15 +61,15 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-              <time><span class="list-day">2017-10-13</span></time>
+              <time><span class="list-day">2017.10.13</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-              <time><span class="list-day">2017-07-19</span></time>
+              <time><span class="list-day">2017.07.19</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016-11-29</span></time>
+              <time><span class="list-day">2016.11.29</span></time>
             </li>
 
           </ul>

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -61,15 +61,15 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-              <time><span class="list-day">2017.10.13</span></time>
+              <time><span class="list-day">2017-10-13</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-              <time><span class="list-day">2017.07.19</span></time>
+              <time><span class="list-day">2017-07-19</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016.11.29</span></time>
+              <time><span class="list-day">2016-11-29</span></time>
             </li>
 
           </ul>

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -61,15 +61,15 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいたら興奮した話</a>
-              <time><span class="list-day">2017-10-13</span></time>
+              <time datetime="2017-10-13"><span class="list-day">2017-10-13</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/19/slideshare/">アクセシブルにするならSlideShareを選ぶべき？SlideShareへのアップロード方法</a>
-              <time><span class="list-day">2017-07-19</span></time>
+              <time datetime="2017-07-19"><span class="list-day">2017-07-19</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016-11-29</span></time>
+              <time datetime="2016-11-29"><span class="list-day">2016-11-29</span></time>
             </li>
 
           </ul>

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017-12-10</span></time>
+              <time><span class="list-day">2017.12.10</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017-07-25</span></time>
+              <time><span class="list-day">2017.07.25</span></time>
             </li>
 
           </ul>

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017.12.10</span></time>
+              <time><span class="list-day">2017-12-10</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017.07.25</span></time>
+              <time><span class="list-day">2017-07-25</span></time>
             </li>
 
           </ul>

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017-12-10</span></time>
+              <time datetime="2017-12-10"><span class="list-day">2017-12-10</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017-07-25</span></time>
+              <time datetime="2017-07-25"><span class="list-day">2017-07-25</span></time>
             </li>
 
           </ul>

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -61,7 +61,7 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020-05-07</span></time>
+              <time datetime="2020-05-07"><span class="list-day">2020-05-07</span></time>
             </li>
 
           </ul>

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -61,7 +61,7 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020.05.07</span></time>
+              <time><span class="list-day">2020-05-07</span></time>
             </li>
 
           </ul>

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -61,7 +61,7 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020-05-07</span></time>
+              <time><span class="list-day">2020.05.07</span></time>
             </li>
 
           </ul>

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017.07.25</span></time>
+              <time><span class="list-day">2017-07-25</span></time>
             </li>
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016.11.29</span></time>
+              <time><span class="list-day">2016-11-29</span></time>
             </li>
 
           </ul>

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017-07-25</span></time>
+              <time datetime="2017-07-25"><span class="list-day">2017-07-25</span></time>
             </li>
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016-11-29</span></time>
+              <time datetime="2016-11-29"><span class="list-day">2016-11-29</span></time>
             </li>
 
           </ul>

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/07/25/brain-science/">影があるとなぜ立体だと認識するのか？インターフェイスの仮説を脳科学から考える</a>
-              <time><span class="list-day">2017-07-25</span></time>
+              <time><span class="list-day">2017.07.25</span></time>
             </li>
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2016/11/29/web-accessibility/">目が見えない状態を想定したUI設計</a>
-              <time><span class="list-day">2016-11-29</span></time>
+              <time><span class="list-day">2016.11.29</span></time>
             </li>
 
           </ul>

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-              <time><span class="list-day">2018.05.11</span></time>
+              <time><span class="list-day">2018-05-11</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017.08.04</span></time>
+              <time><span class="list-day">2017-08-04</span></time>
             </li>
 
           </ul>

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-              <time><span class="list-day">2018-05-11</span></time>
+              <time><span class="list-day">2018.05.11</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017-08-04</span></time>
+              <time><span class="list-day">2017.08.04</span></time>
             </li>
 
           </ul>

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/11/orangebomb-symbol-making/">どのような理由と思考でこのブログのシンボルマークができたのか</a>
-              <time><span class="list-day">2018-05-11</span></time>
+              <time datetime="2018-05-11"><span class="list-day">2018-05-11</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017-08-04</span></time>
+              <time datetime="2017-08-04"><span class="list-day">2017-08-04</span></time>
             </li>
 
           </ul>

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -61,17 +61,17 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-              <time><span class="list-day">2017-10-02</span></time>
+              <time><span class="list-day">2017.10.02</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-              <time><span class="list-day">2017-08-25</span></time>
+              <time><span class="list-day">2017.08.25</span></time>
             </li>
             
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-              <time><span class="list-day">2017-02-03</span></time>
+              <time><span class="list-day">2017.02.03</span></time>
             </li>
 
           </ul>

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -61,17 +61,17 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-              <time><span class="list-day">2017.10.02</span></time>
+              <time><span class="list-day">2017-10-02</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-              <time><span class="list-day">2017.08.25</span></time>
+              <time><span class="list-day">2017-08-25</span></time>
             </li>
             
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-              <time><span class="list-day">2017.02.03</span></time>
+              <time><span class="list-day">2017-02-03</span></time>
             </li>
 
           </ul>

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -61,17 +61,17 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/10/02/sangosan/">多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？ 〜インターネットで 可能性をつなげる、ひろげる〜</a>
-              <time><span class="list-day">2017-10-02</span></time>
+              <time datetime="2017-10-02"><span class="list-day">2017-10-02</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/25/career-keynote/">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
-              <time><span class="list-day">2017-08-25</span></time>
+              <time datetime="2017-08-25"><span class="list-day">2017-08-25</span></time>
             </li>
             
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/02/03/output/">目標設定が下手な自分と、デザイナーのアウトプットに関するヒント</a>
-              <time><span class="list-day">2017-02-03</span></time>
+              <time datetime="2017-02-03"><span class="list-day">2017-02-03</span></time>
             </li>
 
           </ul>

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020.05.07</span></time>
+              <time><span class="list-day">2020-05-07</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017.08.04</span></time>
+              <time><span class="list-day">2017-08-04</span></time>
             </li>
 
           </ul>

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020-05-07</span></time>
+              <time datetime="2020-05-07"><span class="list-day">2020-05-07</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017-08-04</span></time>
+              <time datetime="2017-08-04"><span class="list-day">2017-08-04</span></time>
             </li>
 
           </ul>

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -61,11 +61,11 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/">なぜなに人間中心設計（HCD）</a>
-              <time><span class="list-day">2020-05-07</span></time>
+              <time><span class="list-day">2020.05.07</span></time>
             </li>
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/08/04/lolipop-rebranding/">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜 / Design Casual Talks #2</a>
-              <time><span class="list-day">2017-08-04</span></time>
+              <time><span class="list-day">2017.08.04</span></time>
             </li>
 
           </ul>

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-              <time><span class="list-day">2018-05-01</span></time>
+              <time><span class="list-day">2018.05.01</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017-12-10</span></time>
+              <time><span class="list-day">2017.12.10</span></time>
             </li>
 
           </ul>

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-              <time><span class="list-day">2018.05.01</span></time>
+              <time><span class="list-day">2018-05-01</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017.12.10</span></time>
+              <time><span class="list-day">2017-12-10</span></time>
             </li>
 
           </ul>

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -61,12 +61,12 @@
 
             <li>
               <a href="https://blog.orangebomb.org/blog/2018/05/01/80s-tv-title/">Photoshopを使った80年代風のタイトル画像の作り方</a>
-              <time><span class="list-day">2018-05-01</span></time>
+              <time datetime="2018-05-01"><span class="list-day">2018-05-01</span></time>
             </li>
           
             <li>
               <a href="https://blog.orangebomb.org/blog/2017/12/10/anaglyph/">Photoshopを使って一枚の画像でアナグリフ（3D画像）を作るチュートリアル</a>
-              <time><span class="list-day">2017-12-10</span></time>
+              <time datetime="2017-12-10"><span class="list-day">2017-12-10</span></time>
             </li>
 
           </ul>


### PR DESCRIPTION
https://developer.mozilla.org/ja/docs/Web/HTML/Element/time に準拠し、time要素に `datetime` の値を追加する。
表示のさせ方を趣味で `0000.00.00`のピリオド形式にしようとしたが標準的でないことがわかったので、目に見える表示的にも[国際標準規格ISO 8601](https://ja.wikipedia.org/wiki/%E6%97%A5%E4%BB%98)の拡張表記のハイフンのままにする。