### PR TITLE
プロフィール微修正：准専門家という解釈を外す

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -108,7 +108,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -136,7 +136,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -246,7 +246,7 @@ Keynoteの文字が消える問題の解決対応がまだ先になりそうなS
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -113,7 +113,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -108,7 +108,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -106,7 +106,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -127,7 +127,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -260,7 +260,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -134,7 +134,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -160,7 +160,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -197,7 +197,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -103,7 +103,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/blog/2020/12/22/electromagnetic-waves-and-light--color-and-vision/index.html
+++ b/blog/2020/12/22/electromagnetic-waves-and-light--color-and-vision/index.html
@@ -190,7 +190,7 @@
       <div class="author">
         <div class="author-image"></div>
         <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-        <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+        <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
       </div>
       <ul class="social">
         <li>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       <div class="author">
         <div class="author-image"></div>
         <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-        <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+        <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
       </div>
       <ul class="social">
         <li>

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -80,7 +80,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -80,7 +80,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -72,7 +72,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/index.html
+++ b/tags/index.html
@@ -74,7 +74,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -77,7 +77,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -76,7 +76,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -82,7 +82,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -76,7 +76,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -77,7 +77,7 @@
   <div class="author">
     <div class="author-image"></div>
     <p class="author-name"><a href="https://twitter.com/keita_kawamoto" target="_blank">@keita_kawamoto</a></p>
-    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト（准専門家）。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
+    <p class="author-bio">HCD-Net認定 人間中心設計スペシャリスト。認知科学入門中。わからないをなくす研究。映画とAce Combat / Fallout / RDRと将棋が大好き。</p>
   </div>
   <ul class="social">
     <li>


### PR DESCRIPTION
専門家とスペシャリストというものは上下関係ではなく、種類の話であるという話をHCD-Netの方に聞いた。
作られた背景を調べないと判断できないが、HCD-Netの中で定まっていない可能性もあるため、准専門家というラベルを外す。

調べるのは未来にて。