### PR TITLE
Blogの改良

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -155,7 +155,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/02/03/output/index.html
+++ b/blog/2017/02/03/output/index.html
@@ -183,7 +183,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/07/19/slideshare/index.html
+++ b/blog/2017/07/19/slideshare/index.html
@@ -293,7 +293,7 @@ Keynoteの文字が消える問題の解決対応がまだ先になりそうなS
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -160,7 +160,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -155,7 +155,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -153,7 +153,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -174,7 +174,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -307,7 +307,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2017/12/10/anaglyph/index.html
+++ b/blog/2017/12/10/anaglyph/index.html
@@ -181,7 +181,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2018/05/01/80s-tv-title/index.html
+++ b/blog/2018/05/01/80s-tv-title/index.html
@@ -207,7 +207,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2018/05/11/orangebomb-symbol-making/index.html
+++ b/blog/2018/05/11/orangebomb-symbol-making/index.html
@@ -244,7 +244,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -150,7 +150,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/blog/2020/12/22/electromagnetic-waves-and-light--color-and-vision/index.html
+++ b/blog/2020/12/22/electromagnetic-waves-and-light--color-and-vision/index.html
@@ -237,7 +237,7 @@
         </li>
       </ul>
       <p class="copyright">
-        <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+        <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
       </p>
     </footer>
 

--- a/blog/2021/12/28/rubykaigi2019-1/index.html
+++ b/blog/2021/12/28/rubykaigi2019-1/index.html
@@ -260,7 +260,7 @@
         </li>
       </ul>
       <p class="copyright">
-        <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+        <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
       </p>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="generator" content="Hugo 0.70.0" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <meta name="author" content="keita_kawamoto">
@@ -187,7 +186,7 @@
         </li>
       </ul>
       <p class="copyright">
-        <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+        <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
       </p>
     </footer>
 

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -127,7 +127,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>アクセシビリティ &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:アクセシビリティ &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="アクセシビリティ - Orangebomb">
+  <meta name="twitter:title" content="Tags:アクセシビリティ - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/accessibility/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="アクセシビリティ - Orangebomb">
+  <meta property="og:title" content="Tags:アクセシビリティ - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/accessibility/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:アクセシビリティ</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>認知科学/原理/法則 &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:認知科学/原理/法則 &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="認知科学/原理/法則 - Orangebomb">
+  <meta name="twitter:title" content="Tags:認知科学/原理/法則 - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/cognitive-science-principle-rule/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="認知科学/原理/法則 - Orangebomb">
+  <meta property="og:title" content="Tags:認知科学/原理/法則 - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/cognitive-science-principle-rule/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:認知科学/原理/法則</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/cognitive-science-principle-rule/index.html
+++ b/tags/cognitive-science-principle-rule/index.html
@@ -127,7 +127,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -119,7 +119,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/hcd/index.html
+++ b/tags/hcd/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>人間中心設計（HCD） &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:人間中心設計（HCD）&nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="人間中心設計（HCD） - Orangebomb">
+  <meta name="twitter:title" content="Tags:人間中心設計（HCD）- Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/hcd/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="人間中心設計（HCD） - Orangebomb">
+  <meta property="og:title" content="Tags:人間中心設計（HCD）- Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/hcd/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:人間中心設計（HCD）</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/index.html
+++ b/tags/index.html
@@ -121,7 +121,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>インターフェイス/インタラクション &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:インターフェイス/インタラクション &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="インターフェイス/インタラクション - Orangebomb">
+  <meta name="twitter:title" content="Tags:インターフェイス/インタラクション - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/interface-interaction/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="インターフェイス/インタラクション - Orangebomb">
+  <meta property="og:title" content="Tags:インターフェイス/インタラクション - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/interface-interaction/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:インターフェイス/インタラクション</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/interface-interaction/index.html
+++ b/tags/interface-interaction/index.html
@@ -124,7 +124,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -127,7 +127,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/making/index.html
+++ b/tags/making/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>メイキング &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:メイキング &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="メイキング - Orangebomb">
+  <meta name="twitter:title" content="Tags:メイキング - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/making/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="メイキング - Orangebomb">
+  <meta property="og:title" content="Tags:メイキング - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/making/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:メイキング</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>その他 &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:その他 &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="その他 - Orangebomb">
+  <meta name="twitter:title" content="Tags:その他 - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/other/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="その他 - Orangebomb">
+  <meta property="og:title" content="Tags:その他 - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/other/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:その他</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/other/index.html
+++ b/tags/other/index.html
@@ -129,7 +129,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>リサーチ/分析 &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:リサーチ/分析 &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="リサーチ/分析 - Orangebomb">
+  <meta name="twitter:title" content="Tags:リサーチ/分析 - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/research-analysis/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="リサーチ/分析 - Orangebomb">
+  <meta property="og:title" content="Tags:リサーチ/分析 - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/research-analysis/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:リサーチ/分析</h1>
           </header>
           <ul class="archives-list">
 

--- a/tags/research-analysis/index.html
+++ b/tags/research-analysis/index.html
@@ -123,7 +123,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -124,7 +124,7 @@
     </li>
   </ul>
   <p class="copyright">
-    <small><span class="copy-c">&copy;</span> keita_kawamoto Powered by <a href="http://gohugo.io" target="_blank">Hugo</a></small>
+    <small><span class="copy-c">&copy;</span> keita_kawamoto</small>
   </p>
 </footer>
 

--- a/tags/tutorial/index.html
+++ b/tags/tutorial/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-    <title>チュートリアル &nbsp;-&nbsp; Orangebomb</title>
+    <title>Tags:チュートリアル &nbsp;-&nbsp; Orangebomb</title>
 
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="チュートリアル - Orangebomb">
+  <meta name="twitter:title" content="Tags:チュートリアル - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/tags/tutorial/">
   <meta name="twitter:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
-  <meta property="og:title" content="チュートリアル - Orangebomb">
+  <meta property="og:title" content="Tags:チュートリアル - Orangebomb">
   <meta property="og:url" content="https://blog.orangebomb.org/tags/tutorial/">
   <meta property="og:description" content="@keita_kawamotoのブログ。学習していること研究していることに関わる記事を書いています。">
 
@@ -55,7 +55,7 @@
       <article>
         <div class="container-inner">
           <header>
-            <h1>Archives</h1>
+            <h1>Tags:チュートリアル</h1>
           </header>
           <ul class="archives-list">
 


### PR DESCRIPTION
- [x] Hugoに関する記述を削除
- [x] Tagsの見出し・タイトルを調整
- [ ] a要素のtargetをすべて取り外す
- [ ] ブログのスライドのspeakerdeck化
- [ ] HCD記事を「HCDとは？」に変更
  - [ ] ラストアップデート形式にして、ISOの新しいものの文言にアップデート、各パートの関連手法に合わせたアップデート（今のスライドが少し関連手法のグルーピングに間違いがあるっぽいので修正。また、参照元の明記もする）
- [ ] ブログのフォントサイズなど読みやすさアップデート（NotionとNoteを参考にする）