### PR TITLE
HCDサイクルのスライドをアップデート版に差し替え

### DIFF
--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -75,7 +75,7 @@
 
       <p>
         <iframe src="//www.slideshare.net/slideshow/embed_code/key/EbUOeG6mwCq0Fq" width="595" height="382" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen> </iframe>
-        <strong><a href="//www.slideshare.net/keitakawamoto/hcdpdf" title="なぜなに人間中心設計（HCD） アップデート版" target="_blank">なぜなに人間中心設計（HCD） アップデート版</a> </strong> from <strong><a href="//www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
+        <strong><a href="//www.slideshare.net/keitakawamoto/hcdpdf" title="なぜなに人間中心設計（HCD）" target="_blank">なぜなに人間中心設計（HCD）</a> </strong> from <strong><a href="//www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
       </p>
 
 <p>発表中、HCDサイクルの図のページの時に写真を撮っている人が何名かいたので「あとでアップするので安心してください〜」と伝えると「先に言ってw」というフランクなツッコミをいただきました。ホンマやでw その通りなので次回からは発表前の告知を忘れないようにしたい（このブログ記事は５ヶ月も経過して公開したが、スライドはイベント後すぐにアップしTwitterでシェアし有言実行を果たしている）。</p>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -74,8 +74,8 @@
       <p>まだ新型コロナウイルスが蔓延していなかった去年の12月、<a href="https://uxmilk.connpass.com/event/158445/">UX JAM in FUKUOKA 02</a>で「なぜなに人間中心設計（HCD）」というタイトルで発表させていただきました。端的に「人間中心設計とは何か？」ということを解説しているので、短い時間でざっくりとした概要を知っていただけます。</p>
 
       <p>
-        <iframe src="//www.slideshare.net/slideshow/embed_code/key/ae7YQPep0TTVFo" width="595" height="371" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-        <strong><a href="//www.slideshare.net/keitakawamoto/hcd-207201400" title="なぜなに人間中心設計（HCD）" target="_blank">なぜなに人間中心設計（HCD）</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
+        <iframe src="//www.slideshare.net/slideshow/embed_code/key/EbUOeG6mwCq0Fq" width="595" height="382" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen> </iframe>
+        <strong><a href="//www.slideshare.net/keitakawamoto/hcdpdf" title="なぜなに人間中心設計（HCD） アップデート版" target="_blank">なぜなに人間中心設計（HCD） アップデート版</a> </strong> from <strong><a href="//www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
       </p>
 
 <p>発表中、HCDサイクルの図のページの時に写真を撮っている人が何名かいたので「あとでアップするので安心してください〜」と伝えると「先に言ってw」というフランクなツッコミをいただきました。ホンマやでw その通りなので次回からは発表前の告知を忘れないようにしたい（このブログ記事は５ヶ月も経過して公開したが、スライドはイベント後すぐにアップしTwitterでシェアし有言実行を果たしている）。</p>


### PR DESCRIPTION
- https://blog.orangebomb.org/blog/2020/05/07/what-is-hcd/ に、2019年末の登壇スライドを掲載している。
- そのスライドの中で言及しているHCDサイクルの中身が少々望ましくない間違いとも解釈できる状態になっていた。
- そのため2022.9アップデート版を作成、アップロードしたため、記事の中のスライドそのスライドに差し替える。