### PR TITLE
iframeのmax-width:100%;の設定を復帰

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -33,6 +33,10 @@ p {
   font-size: .8em;
 }
 
+iframe {
+  max-width: 100%;
+}
+
 hr {
   height: 0px;
   margin: 20px 0;


### PR DESCRIPTION
https://github.com/keitakawamoto/keitakawamoto.github.io/pull/29
iframeのスタイル削除はSlideShare用のメディアクエリのみだけが必要で、`max-width` は必要だったのを忘れていた。戻す。