### PR TITLE
iframeのレスポンシブ対応（以前より汎用的な指定方法を採用）

### DIFF
--- a/blog/2016/11/29/web-accessibility/index.html
+++ b/blog/2016/11/29/web-accessibility/index.html
@@ -74,10 +74,10 @@
       <p>視覚がない、弱い人はどのようにサイトを利用しているのか、使っているのはどんなインターフェイスなのか。ずっと気になっていたというのもあり、「目が見えない状態を想定したUI設計」という内容で、主催した勉強会 <a href="https://dct.connpass.com/event/36278/">Design Casual Talks #1</a> で発表をしました。</p>
 <p>インターフェイスとは目で見えるものだけではなく、音声だけで構成されるインターフェイスもある。では僕らがページを作るとき、具体的にどうすればいいのか？</p>
 
-<p>
-  <iframe src="//www.slideshare.net/slideshow/embed_code/key/Cpex3V1VvjsR8N" width="595" height="456" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-  <strong><a href="//www.slideshare.net/keitakawamoto/ui-69634113" title="目が見えない状態を想定したUI設計" target="_blank">目が見えない状態を想定したUI設計</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-</p>
+<div class="iframe-slideshare">
+  <iframe src="//www.slideshare.net/slideshow/embed_code/key/Cpex3V1VvjsR8N" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen=""></iframe>
+  <a href="//www.slideshare.net/keitakawamoto/ui-69634113" title="目が見えない状態を想定したUI設計">目が見えない状態を想定したUI設計</a>
+</div>
 
 <h2 id="出典参考文献">出典・参考文献</h2>
 <p>すべて2016年9月時点（スライド作成時）の情報を参考にしました。</p>

--- a/blog/2017/07/25/brain-science/index.html
+++ b/blog/2017/07/25/brain-science/index.html
@@ -82,10 +82,10 @@
 </ul>
 <p>今回はこの２点の事象について調べてみた。</p>
 
-<p>
-  <iframe src="//www.slideshare.net/slideshow/embed_code/key/Fnj5btpUw75koy" width="595" height="481" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-  <strong><a href="//www.slideshare.net/keitakawamoto/ss-78220226" title="インターフェイスの仮説を脳科学から考える" target="_blank">インターフェイスの仮説を脳科学から考える</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-</p>
+<div class="iframe-slideshare">
+  <iframe src="//www.slideshare.net/slideshow/embed_code/key/Fnj5btpUw75koy" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen=""></iframe>
+  <a href="//www.slideshare.net/keitakawamoto/ss-78220226" title="インターフェイスの仮説を脳科学から考える">インターフェイスの仮説を脳科学から考える</a>
+</div>
 
 <h2 id="出典参考文献">出典・参考文献</h2>
 <p>以下の文献の情報を参考にしました。</p>

--- a/blog/2017/08/04/lolipop-rebranding/index.html
+++ b/blog/2017/08/04/lolipop-rebranding/index.html
@@ -76,10 +76,10 @@
 <p>結果開始からリリースまで１年ほどかかりました。デザイナーのひとりとして最初から最後まで携わった身として、共同主催でやったデザイン勉強会 <a href="https://dct.connpass.com/event/62061/">Design Casual Talks #2</a> にて「僕の視点で見たロリポップ！リブランディング」というタイトルで発表しました。</p>
 <p>15年以上ずっと大きな変化をすることができなかったサービスをどのように生まれ変わらせたのか？</p>
 
-<p>
-  <iframe src="//www.slideshare.net/slideshow/embed_code/key/dc3SsLViR6EpaY" width="595" height="371" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-  <strong><a href="//www.slideshare.net/keitakawamoto/key-78552405" title="僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜" target="_blank">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-</p>
+<div class="iframe-slideshare">
+  <iframe src="//www.slideshare.net/slideshow/embed_code/key/dc3SsLViR6EpaY" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen=""></iframe>
+  <a href="//www.slideshare.net/keitakawamoto/key-78552405" title="僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜">僕の視点で見たロリポップ！リブランディング〜開始からリリースまで〜</a>
+</div>
 
 <h2 id="イベントの様子">イベントの様子</h2>
 <p>前回よりも多くの方にお越しいただけて、とても楽しい勉強会になりました。

--- a/blog/2017/08/25/career-keynote/index.html
+++ b/blog/2017/08/25/career-keynote/index.html
@@ -77,10 +77,10 @@
 <p>というものです。要するに「これまで自分が歩んで来た道のりの過程で生成された自分の根幹部分を、他者に共有する “資料” およびその “発表の場” 」だと僕は認識しています。詳しくは<a href="https://twitter.com/hfm">@hfm</a>の記事 <a href="http://blog.hifumi.info/2016/06/20/career-keynote/">キャリアキーノートとはなにか</a> をご覧ください。</p>
 <p>今年の春、会社に新卒の７期生たちが入社しました。その後の新卒研修の中で、各職種から１名ずつ発表する方式のキャリアキーノートのパートがあり、僕がデザイナー枠として参加できることになりました。今回はそこで発表した内容を掲載します。なんやかんやで公開し損ねてました。僕が学校を卒業し、就職し、そして今に至るまでどんな道を歩み何を得たのかがわかります。</p>
 
-<p>
-  <iframe src="//www.slideshare.net/slideshow/embed_code/key/HfDZs9V9kOQnbT" width="595" height="371" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-  <strong><a href="//www.slideshare.net/keitakawamoto/2017-79127489" title="迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜" target="_blank">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-</p>
+<div class="iframe-slideshare">
+  <iframe src="//www.slideshare.net/slideshow/embed_code/key/HfDZs9V9kOQnbT" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen=""></iframe>
+  <a href="//www.slideshare.net/keitakawamoto/2017-79127489" title="迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜">迷い彷徨った先で見つけた自分の進むべき道〜キャリアキーノート2017〜</a>
+</div>
 
 <p>ヒューマンアカデミー、当時は長崎校が出島にあったんです。今はなくなってしまいましたが&hellip;。四つ折りにする紙の話、実際に７期生たちがやってみたところ、2/3がその通り中央よりほんの少し上に点を打っていました。残りの1/3は本当の中央に点を打っていたので、 「人間は本当の中央より ほんの少しだけ上を中央と感じ<del>る</del>がち」というところでしょうか。みなさんも試してみてくださいね。</p>
 <p><img src="/images/post/20170825career-keynote/20170825career-keynote_1.png" alt="資料発表中の様子"></p>

--- a/blog/2017/10/02/sangosan/index.html
+++ b/blog/2017/10/02/sangosan/index.html
@@ -75,10 +75,10 @@
       <p>長崎県の五島列島、福江島。かつて珊瑚漁でさかえた港町に<a href="http://sangosan.net/">さんごさん</a>という、築80年の古い民家を改装し新設された図書館があります。そのさんごさん主催で<a href="https://www.facebook.com/sangosan/posts/826383214190495">おとな小学校　デザインの時間「島でデザインを考えよう」</a>というイベントが行われ、ご縁があってペパボのメンバーで登壇させていただきました。</p>
 <p>一生懸命頑張って、素敵なアイデア商品を生み出した！多くの人に伝えたい。広めたい。そんなとき、一体どうすればよいのか？</p>
 
-<p>
-  <iframe src="//www.slideshare.net/slideshow/embed_code/key/IIK5y5fdEo9hin" width="595" height="371" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen=""></iframe>
-  <strong><a href="//www.slideshare.net/keitakawamoto/ss-80337485" title="インターネットで 可能性をつなげる、ひろげる 〜ペパボ福岡デザインチーム〜" target="_blank">インターネットで 可能性をつなげる、ひろげる 〜ペパボ福岡デザインチーム〜</a></strong> from <strong><a href="https://www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-</p>
+<div class="iframe-slideshare">
+  <iframe src="//www.slideshare.net/slideshow/embed_code/key/IIK5y5fdEo9hin" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen=""></iframe>
+  <a href="//www.slideshare.net/keitakawamoto/ss-80337485" title="インターネットで 可能性をつなげる、ひろげる 〜ペパボ福岡デザインチーム〜">インターネットで 可能性をつなげる、ひろげる 〜ペパボ福岡デザインチーム〜</a>
+</div>
 
 <p>この発表内容に含まれていた「レンタルサーバー」+「独自ドメイン」で作ったサイトが「拠点」に最適であるという話についてはこちらでも語られています。</p>
 <ul>

--- a/blog/2020/05/07/what-is-hcd/index.html
+++ b/blog/2020/05/07/what-is-hcd/index.html
@@ -73,10 +73,10 @@
     <div class="post-inner">
       <p>まだ新型コロナウイルスが蔓延していなかった去年の12月、<a href="https://uxmilk.connpass.com/event/158445/">UX JAM in FUKUOKA 02</a>で「なぜなに人間中心設計（HCD）」というタイトルで発表させていただきました。端的に「人間中心設計とは何か？」ということを解説しているので、短い時間でざっくりとした概要を知っていただけます。</p>
 
-      <p>
-        <iframe src="//www.slideshare.net/slideshow/embed_code/key/EbUOeG6mwCq0Fq" width="595" height="382" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen> </iframe>
-        <strong><a href="//www.slideshare.net/keitakawamoto/hcdpdf" title="なぜなに人間中心設計（HCD）" target="_blank">なぜなに人間中心設計（HCD）</a> </strong> from <strong><a href="//www.slideshare.net/keitakawamoto" target="_blank">Keita Kawamoto</a></strong>
-      </p>
+      <div class="iframe-slideshare">
+        <iframe src="//www.slideshare.net/slideshow/embed_code/key/EbUOeG6mwCq0Fq" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen></iframe>
+        <a href="//www.slideshare.net/keitakawamoto/hcdpdf" title="なぜなに人間中心設計（HCD）">なぜなに人間中心設計（HCD）</a>
+      </div>
 
 <p>発表中、HCDサイクルの図のページの時に写真を撮っている人が何名かいたので「あとでアップするので安心してください〜」と伝えると「先に言ってw」というフランクなツッコミをいただきました。ホンマやでw その通りなので次回からは発表前の告知を忘れないようにしたい（このブログ記事は５ヶ月も経過して公開したが、スライドはイベント後すぐにアップしTwitterでシェアし有言実行を果たしている）。</p>
 <p>フレンドリーなツッコミを受けるのもこういうイベントの心地良さなんだよな〜、またリアルイベントで登壇したい。新型コロナが収束したら、リアルイベントの良さとリモートイベントの良さを両取りする新しい形態が生まれないだろうか？リアルに介した時の会場のインタラクションの速度・空気感が一番心地よいのは間違いないが、リモートの「住んでいる場所を選ばない」「小さなお子さんがいる家庭のクリエイターも参加しやすい」という良さはリアルイベントにはない。</p>

--- a/blog/2022/06/13/rubykaigi2019-3/index.html
+++ b/blog/2022/06/13/rubykaigi2019-3/index.html
@@ -128,14 +128,18 @@
 
             <section>
               <h2 id="3">RubyKaigi 2019 TOUR</h2>
-              <iframe width="590" height="332" src="https://www.youtube.com/embed/tBjfmrxyboM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              <div class="iframe">
+                <iframe src="https://www.youtube.com/embed/tBjfmrxyboM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              </div>
               <p>RubyKaigi 2019 最終日の会場の様子を関係者で撮影した。会場の全体の様子を体験できます。カメラマンこと私はド素人の初心者なのでいろいろ許してください。</p>
               <p>いろいろなところに張り紙があるが、テーマがあったおかげで色やフォントで悩むことなく必要になった張り紙を容易に用意することができた。世界観が統一されたテーマがあるってやはり便利だ。</p>
             </section>
 
             <section>
               <h2 id="4">Session</h2>
-              <iframe width="590" height="332" src="https://www.youtube.com/embed/odmlf_ezsBo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              <div class="iframe">
+                <iframe src="https://www.youtube.com/embed/odmlf_ezsBo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              </div>
               <p>とにかく、主役はRuby！コード！Rubyist！発表！である。装飾や彩りはあくまで彩り以上になることはない。RubyKaigiでは各セッションをYouTubeで公開しており、誰でも観ることができます。</p>
               <ul>
                 <li><a href="https://www.youtube.com/playlist?list=PLbFmgWm555yYc9_jx9HkS_1WkOLKWnRw3">RubyKaigi 2019 - YouTube：65本の動画のプレイリスト</a></li>

--- a/blog/2022/10/30/freee-2022/index.html
+++ b/blog/2022/10/30/freee-2022/index.html
@@ -63,13 +63,17 @@
           </header>
           <div class="post-inner">
             <p>今年の８月、<a href="https://freee.connpass.com/event/255107/">freee Design Night in Fukuoka</a>でオンライン登壇をしました。リサーチがテーマだったので、デザインリサーチ・UXリサーチに関する考え方についての内容です。相手の声を鵜呑みにしてはいけない、文脈や背景が違えば意味が変わる、先入観に操られないようにまず考えられる可能性をできるだけ捉える、などを解説しています。</p>
-            <p><iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/382e7093ffa24cd9a85e4fa2f257e20d" title="考えられる可能性を知る - 多角的に捉える訓練" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 590px; height: 332px;" data-ratio="1.7777777777777777"></iframe></p>
+            <div class="iframe">
+              <iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/382e7093ffa24cd9a85e4fa2f257e20d" title="考えられる可能性を知る - 多角的に捉える訓練" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px;" data-ratio="1.7777777777777777"></iframe>
+            </div>
             <p>ほかの登壇者はおそらく実務的な内容を発表なされるのではと考え、あまりリサーチノウハウ解説において触れられないような内容をまとめてはどうか？というのがこの内容にした背景でした。</p>
 
             <section>
               <h2>イベントの様子</h2>
               <p>YouTubeにアーカイブが残されているので、イベントの内容にはいつでもアクセスできます。私の登壇は３番目（40:00〜）で、その後はファシリテーターと全登壇者でのディスカッションという形式でした。</p>
-              <p><iframe width="590" height="332" src="https://www.youtube.com/embed/IZ_2WSquTx0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></p>
+              <div class="iframe">
+                <iframe src="https://www.youtube.com/embed/IZ_2WSquTx0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+              </div>
               <p>２年ぶりの登壇は楽しかったです。他のお二人の発表もとても勉強になるものでした。アウトプットとインプットを両方できるイベントというのはやはりいいものですね。例によって自分の知識を精査し、内容を取捨選択、整頓、余分な情報を削ぎ落とし最終形態に仕上げる、という過程の中で一番恩恵を受けるのは自分自身だなと感じられます。今回の内容では日々の気付きをTwitterにメモし、そのメモ内容をカテゴリ分けして保管しておいたことが大きく役立ちました。ここ数年の自分の学びの結晶、という感じなので、このドキュメントは自分のふりかえり用として今後長く役に立っていくでしょう。油断したらすぐに一つの視点だけで考えてしまいそうになるものです。</p>
             </section>
 

--- a/css/base.css
+++ b/css/base.css
@@ -41,7 +41,16 @@ p {
   height: 0;
 }
 
-.iframe iframe {
+.iframe-slideshare {
+  margin: .2em 0 1.6em;
+  padding-top: 64.7%;
+  position: relative;
+  width: 100%;
+  height: 0;
+}
+
+.iframe iframe,
+.iframe-slideshare iframe {
   position: absolute;
   top: 0;
   left: 0;

--- a/css/base.css
+++ b/css/base.css
@@ -42,7 +42,7 @@ p {
 }
 
 .iframe-slideshare {
-  margin: .2em 0 1.6em;
+  margin: 3.2em 0 4.6em;
   padding-top: 64.7%;
   position: relative;
   width: 100%;

--- a/css/base.css
+++ b/css/base.css
@@ -33,8 +33,20 @@ p {
   font-size: .8em;
 }
 
-iframe {
-  max-width: 100%;
+.iframe {
+  margin: .2em 0 1.6em;
+  padding-top: 56.25%;
+  position: relative;
+  width: 100%;
+  height: 0;
+}
+
+.iframe iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 hr {


### PR DESCRIPTION
https://akros-ac.jp/8277/ で紹介されていたiframeのレスポンシブ対応方法を採用する。
[ペパボテックブログ](https://tech.pepabo.com/2022/04/28/pepabo-tech-talk-sre/)でも同様の指定が使用されていた。`padding-top: 56.25%;` の値はペパボテックブログの値を真似た。16:9用の高さ指定と予測。

- 埋め込みに含まれているstyleの幅・高さの指定は削除する
- SlideShareの場合はUIの高さ含まれ16:9の高さでは成立しないのでSlideShare用のセレクタを設定する