### PR TITLE
細部修正

### DIFF
--- a/blog/2017/10/13/inclusive-design-patterns/index.html
+++ b/blog/2017/10/13/inclusive-design-patterns/index.html
@@ -6,17 +6,17 @@
   <meta name="author" content="keita_kawamoto">
   <meta name="description" content="Heydon Pickeringさん による著書 Inclusive Design Patterns の日本語化&#43;充実の訳注付き版が「インクルーシブHTML&#43;CSS &amp; JavaScript 多様なユーザーニーズに応えるフロントエンドデザインパターン」として発売されます。監訳はピンク本の著者であり、緑本の監訳者である太田良典さんと伊原力也さんのお二人。査読することになったきっかけと、どのような書籍であるかのお話です。">
   
-    <title>インクルーシブ本の査読させていただいた話 &nbsp;-&nbsp; Orangebomb</title>
+    <title>インクルーシブ本の査読をさせていただいた話 &nbsp;-&nbsp; Orangebomb</title>
   
   
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="keita_kawamoto">
   <meta name="twitter:creator" content="keita_kawamoto">
-  <meta name="twitter:title" content="インクルーシブ本の査読させていただいた話 - Orangebomb">
+  <meta name="twitter:title" content="インクルーシブ本の査読をさせていただいた話 - Orangebomb">
   <meta name="twitter:url" content="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">
   <meta name="twitter:description" content="Heydon Pickeringさん による著書 Inclusive Design Patterns の日本語化&#43;充実の訳注付き版が「インクルーシブHTML&#43;CSS &amp; JavaScript 多様なユーザーニーズに応えるフロントエンドデザインパターン」として発売されます。監訳はピンク本の著者であり、緑本の監訳者である太田良典さんと伊原力也さんのお二人。査読することになったきっかけと、どのような書籍であるかのお話です。">
   
-  <meta property="og:title" content="インクルーシブ本の査読させていただいた話">
+  <meta property="og:title" content="インクルーシブ本の査読をさせていただいた話">
   <meta property="og:url" content="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">
   <meta property="og:description" content="Heydon Pickeringさん による著書 Inclusive Design Patterns の日本語化&#43;充実の訳注付き版が「インクルーシブHTML&#43;CSS &amp; JavaScript 多様なユーザーニーズに応えるフロントエンドデザインパターン」として発売されます。監訳はピンク本の著者であり、緑本の監訳者である太田良典さんと伊原力也さんのお二人。査読することになったきっかけと、どのような書籍であるかのお話です。">
   
@@ -55,7 +55,7 @@
       <article>
   <div class="post">
     <header>
-      <h1><a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいた話</a></h1>
+      <h1><a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読をさせていただいた話</a></h1>
       <div class="post-date">
         <div class="day">
           <time datetime="2017-10-13">2017-10-13</time>

--- a/css/base.css
+++ b/css/base.css
@@ -68,7 +68,7 @@ hr {
 /* selection */
 
 ::selection {
-  background: #fa7033;
+  background: #f64400;
   color: #fff;
 }
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                 </li>
 
                 <li>
-                  <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいた話</a>
+                  <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読をさせていただいた話</a>
                   <time datetime="2017-10-13"><span class="list-day">2017-10-13</span></time>
                 </li>
 

--- a/index.xml
+++ b/index.xml
@@ -161,7 +161,7 @@ jpegの質を5%に低下させるのは僕も初めてでした。
     </item>
     
     <item>
-      <title>インクルーシブ本の査読させていただいた話</title>
+      <title>インクルーシブ本の査読をさせていただいた話</title>
       <link>https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/</link>
       <pubDate>Fri, 13 Oct 2017 00:00:00 +0000</pubDate>
       

--- a/tags/accessibility/index.html
+++ b/tags/accessibility/index.html
@@ -51,7 +51,7 @@
           <ul class="archives-list">
 
             <li>
-              <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読させていただいた話</a>
+              <a href="https://blog.orangebomb.org/blog/2017/10/13/inclusive-design-patterns/">インクルーシブ本の査読をさせていただいた話</a>
               <time datetime="2017-10-13"><span class="list-day">2017-10-13</span></time>
             </li>
 


### PR DESCRIPTION
2件調整。

- [反転時の配色をロゴのオレンジ#f64400に変更](https://github.com/keitakawamoto/keitakawamoto.github.io/pull/39/commits/89376febdff9b94bffc59c46588651612d9503d6)
- [文法の誤りを修正](https://github.com/keitakawamoto/keitakawamoto.github.io/pull/39/commits/dc3ce1e375d9c0d03e05a1ea0db3c791e7c2d3f3)
  - インクルーシブ本の査読「を」させていただいた話、に変更。「を」が抜けてたので。