### PR TITLE
::selectionのプロパティをテーマカラーベースでありつつWCAG AAAを満たすものに変更

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -68,8 +68,7 @@ hr {
 /* selection */
 
 ::selection {
-  background: #fa7033;
-  color: #fff;
+  background: rgba(246, 68, 0, 0.1) /* 公式オレンジの#f64400のコードをRGBで表すと246,68,0になる。それを透明度10%にし文字色とのコントラストでWCAG AAAを満たす */;
 }
 
 /* link */


### PR DESCRIPTION
## 内容

https://github.com/keitakawamoto/keitakawamoto.github.io/pull/39 において文字を反転した時の色をテーマカラーに指定し直した。しかしコントラスト差が大きく、望ましいとは言えない仕上がりとなった。そこで追加改修を行う。

公式オレンジの `#f64400` を透明度10%にし文字色とのコントラストでWCAG AAAを満たすよう改修すれば、テーマも満たしユーザビリティも良い状態を満たせる。

サンプル１|サンプル２|今回の修正
---|---|---
<img src="https://github.com/user-attachments/assets/4131afa0-f778-47c8-b62c-b24b0ab58d6c" width="400">|<img src="https://github.com/user-attachments/assets/dac01c38-dfe1-4fb6-b082-fb2f2e6ab43b" width="400">|<img src="https://github.com/user-attachments/assets/21f10b01-eea0-4240-980a-3e1b809e0ff7" width="400">

> ChatGPT: アクセシビリティ評価基準の名前は WCAG (Web Content Accessibility Guidelines) です。このガイドラインは、ウェブコンテンツのアクセシビリティを評価するための国際基準で、3つの適合レベルがあります：
> A（最低基準）
> AA（推奨基準）
> AAA（最高基準）

判定は https://webaim.org/resources/contrastchecker/ で実施。

今回の修正では `background: rgba(246, 68, 0, 0.1)`という値にしたが、これは `#f64400` をRGBに変換し10%の透明度という指定にした文字列。透明度を使用しているので背景色に最終的な色が左右される。ブログの記事部分の背景色は `#f8f9fb` で、GPTに計算させた結果視覚的な出力結果は以下となった。

> ChatGPT: 背景色が `#f8f9fb` の場合、透明度を反映した後の視覚的な出力色は `#F8E7E2` です。

この値を使ってコントラストを判定した結果以下のように合格となった。

https://webaim.org/resources/contrastchecker/?fcolor=333333&bcolor=F8E7E2

|WCAGの判定をパス（文字色 `#333333` に対し反転色が `#F8E7E2` ）|
|---|
|![image](https://github.com/user-attachments/assets/58694f45-c609-4957-84f1-7691145a0a56)|



## 他の箇所について

ブログのスタイリングは多くの問題を抱えている。アクセシビリティ面においても。しかし今は改修する時間がないので作業に含まない。